### PR TITLE
Create multi-target project and update on cache interface

### DIFF
--- a/client/cache/IMyCache.cs
+++ b/client/cache/IMyCache.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Text;
 
 namespace io.harness.cfsdk.client.cache
@@ -31,7 +32,7 @@ namespace io.harness.cfsdk.client.cache
         }
         public IDictionary<K, V> GetAllElements()
         {
-            return CacheMap;
+            return new ReadOnlyDictionary<K, V>(CacheMap);
         }
 
         public void Delete(K key)

--- a/ff-netF48-server-sdk.csproj
+++ b/ff-netF48-server-sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <RootNamespace>io.harness.cfsdk</RootNamespace>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Version>1.0.2</Version>


### PR DESCRIPTION
- Project updated to target both netstandard2 and net461. In both scenarios, we are using the same 3rd party dependency libraries
- Returning read-only cache interface