### PR TITLE
Initialize `privateAttributes` in TargetBuilder

### DIFF
--- a/client/dto/Target.cs
+++ b/client/dto/Target.cs
@@ -62,7 +62,7 @@ namespace io.harness.cfsdk.client.dto
         private string name;
         private Dictionary<string, string> attributes = new Dictionary<string, string>();
         private bool isPrivate; // If the target is private
-        private HashSet<string> privateAttributes; // Custom set to set the attributes which are private
+        private HashSet<string> privateAttributes = new HashSet<string>(); // Custom set to set the attributes which are private
 
         public TargetBuilder()
         {


### PR DESCRIPTION
If creating a target via TargetBuilder, and private attributes aren't specified via `TargetBuilder.PrivateAttributes`, the `privateAttributes` member never gets initialized, which becomes a problem when analytics get published here: https://github.com/drone/ff-dotnet-server-sdk/blob/main/client/api/analytics/AnalyticsPublisherService.cs#L102