### PR TITLE
Update interface to keep backward compatibility

### DIFF
--- a/client/api/CfClient.cs
+++ b/client/api/CfClient.cs
@@ -16,10 +16,10 @@ namespace io.harness.cfsdk.client.api
 
         Task InitializeAndWait();
 
-        bool BoolVariation(string key, dto.Target target, bool defaultValue);
-        string StringVariation(string key, dto.Target target, string defaultValue);
-        double NumberVariation(string key, dto.Target target, double defaultValue);
-        JObject JsonVariation(string key, dto.Target target, JObject defaultValue);
+        bool boolVariation(string key, dto.Target target, bool defaultValue);
+        string stringVariation(string key, dto.Target target, string defaultValue);
+        double numberVariation(string key, dto.Target target, double defaultValue);
+        JObject jsonVariation(string key, dto.Target target, JObject defaultValue);
 
 
         event EventHandler InitializationCompleted;
@@ -89,10 +89,10 @@ namespace io.harness.cfsdk.client.api
         }
 
         // read values
-        public bool BoolVariation(string key, dto.Target target, bool defaultValue) { return client.BoolVariation(key, target, defaultValue);  }
-        public string StringVariation(string key, dto.Target target, string defaultValue) { return client.StringVariation(key, target, defaultValue); }
-        public double NumberVariation(string key, dto.Target target, double defaultValue) { return client.NumberVariation(key, target, defaultValue); }
-        public JObject JsonVariation(string key, dto.Target target, JObject defaultValue) {  return client.JsonVariation(key, target, defaultValue); }
+        public bool boolVariation(string key, dto.Target target, bool defaultValue) { return client.BoolVariation(key, target, defaultValue);  }
+        public string stringVariation(string key, dto.Target target, string defaultValue) { return client.StringVariation(key, target, defaultValue); }
+        public double numberVariation(string key, dto.Target target, double defaultValue) { return client.NumberVariation(key, target, defaultValue); }
+        public JObject jsonVariation(string key, dto.Target target, JObject defaultValue) {  return client.JsonVariation(key, target, defaultValue); }
 
         // force message
         public void Update(Message msg) { client.Update(msg, true);  }

--- a/tests/ff-server-sdk-example/Program.cs
+++ b/tests/ff-server-sdk-example/Program.cs
@@ -86,16 +86,16 @@ namespace io.harness.example
 
                 await client.InitializeAndWait();
 
-                bool bResult = CfClient.Instance.BoolVariation("flag1", target, false);
+                bool bResult = CfClient.Instance.boolVariation("flag1", target, false);
                 Console.WriteLine($"Client: {d.Key} Bool Variation value ----> {bResult}");
 
-                double nResult = CfClient.Instance.NumberVariation("flag2", target, -1);
+                double nResult = CfClient.Instance.numberVariation("flag2", target, -1);
                 Console.WriteLine($"Client: {d.Key} Number Variation value ----> {nResult}");
 
-                string sResult = CfClient.Instance.StringVariation("flag3", target, "NO VALUE!!!!");
+                string sResult = CfClient.Instance.stringVariation("flag3", target, "NO VALUE!!!!");
                 Console.WriteLine($"Client: {d.Key} String Variation value ----> {sResult}");
 
-                JObject jResult = CfClient.Instance.JsonVariation("flag4", target, new JObject());
+                JObject jResult = CfClient.Instance.jsonVariation("flag4", target, new JObject());
                 Console.WriteLine($"Client: {d.Key} Json Variation value ----> {jResult}");
 
             }
@@ -148,10 +148,10 @@ namespace io.harness.example
 
             while (true)
             {
-                bool bResult = client.BoolVariation("flag1", target, false);
+                bool bResult = client.boolVariation("flag1", target, false);
                 Console.WriteLine($"Bool Variation value ----> {bResult}");
 
-                JObject jResult = client.JsonVariation("flag4", target, new JObject());
+                JObject jResult = client.jsonVariation("flag4", target, new JObject());
                 Console.WriteLine($"Bool Variation value ----> {jResult}");
 
                 Thread.Sleep(20000);


### PR DESCRIPTION
- Updating interface to match "older" version for backward compatibility.
BoolVariation --> boolVariation
StringVariation --> stringVariation
NumberVariation --> numberVariation
JsonVariation --> jsonVariation

Note that C# has PascalCase naming conversion for Method name, and we are reverting to camelCase which results in build warnings, but we are keeping backward compatibility with older clients. 
@milos85vasic 